### PR TITLE
:sparkles: Added Version option in input file

### DIFF
--- a/WhiteListSoftware.csv
+++ b/WhiteListSoftware.csv
@@ -1,5 +1,6 @@
 Software
 EShare 1.1.2.103
 Google Chrome
-Microsoft Help Viewer 2.2 
+Microsoft Help Viewer 2.2
+Battle.net
 Windows SDK Modern Non-Versioned Developer Tools

--- a/WhiteListWithVersion
+++ b/WhiteListWithVersion
@@ -1,0 +1,6 @@
+Software,Version
+EShare 1.1.2.103,1
+Google Chrome,94.0.4606.61
+Microsoft Help Viewer 2.2,ND
+Battle.net,3
+Windows SDK Modern Non-Versioned Developer Tools,ND


### PR DESCRIPTION

The csv admit a second parameter called "Version", the log is changed and divided in "whitelist with compliant version", "white list with uncompliant version", "not  in whitelist"
The script is still compliant with files without the second parameter for retrocompatibility. (despite the new log).

Fixed a bug where the notwhitelist softwares logged all the software ignoring the whitelist

If the software has not the version put "ND" (not defined" as version parameter